### PR TITLE
Add missing await so bad stuff doesn't happen

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function run(): Promise<void> {
     const payload = JSON.parse((await readFile(path)).toString())
 
     if (setup) {
-      execCommand(setup)
+      await execCommand(setup )
     }
 
     const exitCode = await execCommand(check, { throw: false })

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function run(): Promise<void> {
     const payload = JSON.parse((await readFile(path)).toString())
 
     if (setup) {
-      await execCommand(setup )
+      await execCommand(setup)
     }
 
     const exitCode = await execCommand(check, { throw: false })


### PR DESCRIPTION
Missed adding an await but since we don't use `setup` in the integration test, this was missed.